### PR TITLE
Remove boost dependencies and fix some compilation problems

### DIFF
--- a/example/testrift.cpp
+++ b/example/testrift.cpp
@@ -127,7 +127,7 @@ public:
         static size_t const TRANSFERS = 64;
         libusbcpp::Transfer transfers[TRANSFERS];
         uint8_t bufs[TRANSFERS][64];
-        boost::function<void()> callbacks[TRANSFERS];
+        std::function<void()> callbacks[TRANSFERS];
         for(size_t i = 0; i < TRANSFERS; i++) {
             transfers[i].fill_interrupt(0x81, bufs[i], 64);
             callbacks[i] = [this, i, &transfers, &bufs, &devp, &callbacks]() {

--- a/example/testrift.cpp
+++ b/example/testrift.cpp
@@ -108,7 +108,7 @@ public:
     }
     
     void run() {
-        libusbcpp::Context ctx;
+        libusbcpp::LibUSBContext ctx;
         std::unique_ptr<libusbcpp::DeviceHandle> devp = ctx.open_device_with_vid_pid(0x2833, 0x0021);
         
         if(devp->kernel_driver_active(0)) {

--- a/libusbcpp.h
+++ b/libusbcpp.h
@@ -7,8 +7,9 @@
 #include <sstream>
 #include <unordered_map>
 #include <vector>
-
-#include <boost/function.hpp>
+#include <functional>
+#include <memory>
+#include <cstring>
 
 #include "libusb.h"
 
@@ -64,7 +65,7 @@ class Transfer {
     libusb_transfer * transfer_;
     bool own_buffer_;
 public:
-    boost::function<void()> callback_;
+    std::function<void()> callback_;
     Transfer(int iso_packets=0) {
         transfer_ = libusb_alloc_transfer(iso_packets);
         if(!transfer_) {
@@ -140,7 +141,7 @@ public:
     virtual void release_interface(int interface_number) = 0;
     virtual void set_interface_alt_setting(int interface_number, int alternate_setting) = 0;
     virtual void submit_sync(Transfer & transfer) = 0;
-    virtual boost::function<void()> submit_async(Transfer & transfer, boost::function<void()> callback) = 0; // returns cancellation function
+    virtual std::function<void()> submit_async(Transfer & transfer, std::function<void()> callback) = 0; // returns cancellation function
 };
 
 class LibUSBDeviceHandle : public DeviceHandle {
@@ -209,7 +210,7 @@ private:
         }
     }
 public:
-    boost::function<void()> submit_async(Transfer & transfer, boost::function<void()> callback) {
+    std::function<void()> submit_async(Transfer & transfer, std::function<void()> callback) {
         transfer.get_transfer().dev_handle = handle_;
         transfer.get_transfer().callback = cb;
         transfer.get_transfer().user_data = &transfer;

--- a/libusbcpp.h
+++ b/libusbcpp.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <boost/function.hpp>
-#include <boost/utility.hpp>
 
 #include "libusb.h"
 
@@ -59,7 +58,9 @@ T check_error(T res) {
     assert(false);
 }
 
-class Transfer : boost::noncopyable {
+class Transfer {
+    Transfer(const Transfer&) = delete;
+    Transfer& operator=(const Transfer&) = delete;
     libusb_transfer * transfer_;
     bool own_buffer_;
 public:
@@ -123,7 +124,11 @@ public:
 
 class Device;
 
-class DeviceHandle : boost::noncopyable {
+class DeviceHandle {
+protected:
+    DeviceHandle() = default;
+    DeviceHandle(const DeviceHandle&) = delete;
+    DeviceHandle& operator=(const DeviceHandle&) = delete;
 public:
     virtual ~DeviceHandle() { };
     virtual Device get_device() = 0;
@@ -250,7 +255,11 @@ inline Device LibUSBDeviceHandle::get_device() {
     return Device(context_, libusb_get_device(handle_));
 }
 
-class Context : boost::noncopyable {
+class Context {
+protected:
+    Context() = default;
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
 public:
     virtual ~Context() { };
     virtual std::vector<Device> get_device_list() = 0;

--- a/libusbcpp.h
+++ b/libusbcpp.h
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #include <boost/foreach.hpp>
 #include <boost/function.hpp>

--- a/libusbcpp.h
+++ b/libusbcpp.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/foreach.hpp>
 #include <boost/function.hpp>
 #include <boost/utility.hpp>
 
@@ -255,9 +254,9 @@ class Context : boost::noncopyable {
 public:
     virtual ~Context() { };
     virtual std::vector<Device> get_device_list() = 0;
-    
+
     std::unique_ptr<DeviceHandle> open_device_with_vid_pid(uint16_t vendor_id, uint16_t product_id) {
-        BOOST_FOREACH(Device const & d, get_device_list()) {
+        for(auto const & d: get_device_list()) {
             libusb_device_descriptor desc = d.get_device_descriptor();
             if(desc.idVendor == vendor_id && desc.idProduct == product_id) {
                 return d.open();


### PR DESCRIPTION
C++11 allows to remove the boost components from the libusbcpp header and replace with built-in or STL equivalents.
- boost::function and std::function are equivalent
- BOOST_FOREACH can be replaced by a range-for loop
- boost::noncopyable is easily represented by the 'deleted' keyword, which is the idiomatic C++11 way to denote disallowed copy operations.

In total, this means that you no longer have to have any access to any other library except libusb to use libusbcpp.

Also here are a couple of compilation / include fixes.
